### PR TITLE
Remove bottle :unneeded

### DIFF
--- a/getoptions.rb
+++ b/getoptions.rb
@@ -4,6 +4,8 @@ class Getoptions < Formula
   url "https://github.com/ko1nksm/getoptions/archive/refs/tags/v3.3.0.tar.gz"
   sha256 "b767c6886d3b3f1258463aca500f9f06ed58f1bc6b11eb6e3e33de66847d4123"
 
+  bottle :unneeded
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end

--- a/getoptions.rb
+++ b/getoptions.rb
@@ -4,8 +4,6 @@ class Getoptions < Formula
   url "https://github.com/ko1nksm/getoptions/archive/refs/tags/v3.3.0.tar.gz"
   sha256 "b767c6886d3b3f1258463aca500f9f06ed58f1bc6b11eb6e3e33de66847d4123"
 
-  bottle :unneeded
-
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end


### PR DESCRIPTION
I left an issue on the main repo. 

```bash
~
❯ brew tap ko1nksm/getoptions
Running `brew update --preinstall`...
[...]

==> Tapping ko1nksm/getoptions
Cloning into '/opt/homebrew/Library/Taps/ko1nksm/homebrew-getoptions'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 9 (delta 0), reused 5 (delta 0), pack-reused 0
Receiving objects: 100% (9/9), 4.36 KiB | 4.36 MiB/s, done.
Error: Invalid formula: /opt/homebrew/Library/Taps/ko1nksm/homebrew-getoptions/getoptions.rb
getoptions: Calling bottle :unneeded is disabled! There is no replacement.
Please report this issue to the ko1nksm/getoptions tap (not Homebrew/brew or Homebrew/core):
  /opt/homebrew/Library/Taps/ko1nksm/homebrew-getoptions/getoptions.rb:7

Error: Cannot tap ko1nksm/getoptions: invalid syntax in tap!

```

Removing line:7 in getoptions.rb solves the error.